### PR TITLE
Add delete method

### DIFF
--- a/pyhpipam/core/api.py
+++ b/pyhpipam/core/api.py
@@ -10,6 +10,7 @@ from pyhpipam.core.exceptions import PyHPIPAMException
 GET = requests.get
 POST = requests.post
 PATCH = requests.patch
+DELETE = requests.delete
 OPTIONS = requests.options
 
 
@@ -114,3 +115,8 @@ class Api(object):
             _path = '{}/{}'.format(_path, _controller_path)
 
         return self._query(token=self._api_token, method=POST, path=_path, data=data)
+
+    def delete_entity(self, controller, controller_path, **kwargs):
+        _path = '{}/{}'.format(controller, controller_path)
+
+        return self._query(token=self._api_token, method=DELETE, path=_path)

--- a/pyhpipam/core/exceptions.py
+++ b/pyhpipam/core/exceptions.py
@@ -15,8 +15,7 @@ class PyHPIPAMException(Exception):
         elif self._code == 400:
             raise PyHPIPAMInvalidSyntax(message=self._message)
         elif self._code == 404:
-            if self._message == 'Not Found':
-                raise PyHPIPAMEntityNotFoundException(self._message)
+            raise PyHPIPAMEntityNotFoundException(self._message)
 
         # super(PyHPIPAMException, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
Add method to delete existing entities. We also changed the `PyHPIPAMEntityNotFound` exception to
handle errors if the entity which should be delete does not exists.