### PR TITLE
provide pytests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+- push
+- pull_request
+
+jobs:
+  tests:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Prepare test environment
+      run: |
+        python -m pip install --upgrade pip
+        make test-setup
+    - name: Run all tests
+      run:
+        make test-all

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "python.pythonPath": "${workspaceFolder}/venv/bin/python",
   "python.autoComplete.extraPaths": ["./tests/scripts"],
   "python.envFile": "${workspaceFolder}/.env",
-  "restructuredtext.confPath": "${workspaceFolder}/docs"
+  "restructuredtext.confPath": "${workspaceFolder}/docs",
+  "python.analysis.extraPaths": [
+    "./tests/scripts"
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,12 @@ doc:
 	sphinx-apidoc -M -f -o docs/plugins/ phpypam
 	make -C docs html
 
-test-setup:
+test-setup: | tests/vars/server.yml
 	pip install --upgrade -r requirements-dev.txt
+
+tests/vars/server.yml:
+	cp $@.example $@
+	@echo "Please configure $@ to point to your phpIPAM instance for recording."
 
 test-all:
 	coverage run -m pytest tests/test_cases/* -v

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,7 @@ setuptools
 PyYAML
 bumpversion
 pytest
+pytest-replay
 pytest-vcr
+pytest-xdist
 coverage

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,40 @@
 """Provide some base configurations for tests."""
 import inspect
+import phpypam
 import pytest
 import py.path
 import re
+import yaml
+
 from urllib.parse import urlparse, urlunparse
 
 TEST_CASES_PATH = py.path.local(__file__).realpath() / '..' / 'test_cases'
+
+with open('tests/vars/server.yml') as c:
+    server = yaml.safe_load(c)
+
+
+@pytest.fixture(scope='module')
+def pi(*arg, **kwargs):
+    """Create a phpypam.api object and return it.
+
+    :return: object phpypam
+    :rtype: phpypam.api
+    """
+    url = kwargs.pop('url', server['url'])
+    app_id = kwargs.pop('app_id', server['app_id'])
+    username = kwargs.pop('username', server['username'])
+    password = kwargs.pop('password', server['password'])
+    ssl_verify = kwargs.pop('ssl_verify', True)
+
+    return phpypam.api(
+        url=url,
+        app_id=app_id,
+        username=username,
+        password=password,
+        ssl_verify=ssl_verify,
+        **kwargs
+    )
 
 
 def find_all_test_cases():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 """Provide some base configurations for tests."""
-import inspect
 import phpypam
 import pytest
 import py.path
-import re
 import yaml
 
 from urllib.parse import urlparse, urlunparse

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,92 @@
+"""Provide some base configurations for tests."""
+import inspect
+import pytest
+import py.path
+import re
+from urllib.parse import urlparse, urlunparse
+
+TEST_CASES_PATH = py.path.local(__file__).realpath() / '..' / 'test_cases'
+
+
+def find_all_test_cases():
+    """Generate list of test cases.
+
+    :yield: generates each test case as list item
+    :rtype: str
+    """
+    for c in TEST_CASES_PATH.listdir(sort=True):
+        c = c.basename
+        if c.endswith('.py'):
+            yield c.replace('.py', '')
+
+
+TEST_CASES = list(find_all_test_cases())
+
+
+def pytest_addoption(parser):
+    """Change command line options defaults.
+
+    We want run our tests only in three modes
+    `live` - interact with an existing API
+    `record` - interact with an existing API and record the interactions
+    `replay` - replay previouly recorded interactions with API
+
+    :param parser: A parser object
+    :type parser: object parser
+    """
+    parser.addoption(
+        "--vcrmode",
+        action="store",
+        default="replay",
+        choices=["replay", "record", "live"],
+        help="mode for vcr recording; one of ['replay', 'record', 'live']",
+    )
+
+
+@pytest.fixture
+def vcrmode(request):
+    """Return vcrmode of a request.
+
+    :param request: A request object
+    :type request: object request
+    :return: vcrmode
+    :rtype: str
+    """
+    return request.config.getoption("vcrmode")
+
+
+def cassette_name(test_name=None):
+    """Generate cassette_name."""
+    return 'tests/fixtures/{0}.yml'.format(test_name)
+
+
+FILTER_REQUEST_HEADERS = ['Authorization', 'Cookie', 'Token']
+FILTER_RESPONSE_HEADERS = ['Apipie-Checksum', 'Date', 'ETag', 'Server', 'Set-Cookie', 'Via', 'X-Powered-By', 'X-Request-Id', 'X-Runtime']
+
+
+def filter_response(response):
+    """Filter headers before recording.
+
+    :param response: A response object where we want to filter the headers from.
+    :type response: object response
+    :return: response
+    :rtype: object response
+    """
+    for header in FILTER_RESPONSE_HEADERS:
+        # headers should be case insensitive, but for some reason they weren't for me
+        response['headers'].pop(header.lower(), None)
+        response['headers'].pop(header, None)
+
+    return response
+
+
+def filter_request_uri(request):
+    """Filter uri before recording.
+
+    :param request: A request object where we want to filter the uri from.
+    :type request: object request
+    :return: request
+    :rtype: object request
+    """
+    request.uri = urlunparse(urlparse(request.uri)._replace(netloc="ipam.example.org"))
+    return request

--- a/tests/fixtures/test_address_not_found.yml
+++ b/tests/fixtures/test_address_not_found.yml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3NTQqDMBAG0KuUb53IZCpCZt/SXaF/CzciySxsUYuJVBDvXg/weCvCGBXCRAZp
+        DkFTguRpVoPY5hayIo8fHSBIL+tPzfXyvoVnPZw12uV3rx4eBrp8u0l3CSYm65yl8sAkRy9cYjPI
+        Xb8vVJDb/o6954ZzAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:24 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=rtcrr3al96v1m7oro2vnsc0lc4; expires=Thu, 05-Nov-2020 13:39:24 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/addresses/search/10.10.0.4
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskqOKSlFQI5CXn6J
+        Qlp+aV6Kko5SSWYuUMpAz8DAtBYAByXdEUcAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:24 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=vl2d6ijho4ddb26e964bhfd8gn; expires=Thu, 05-Nov-2020 13:39:24 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_connection_failure.yml
+++ b/tests/fixtures/test_connection_failure.yml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjUw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskqeeWWJOZkpCqXF
+        qUV5ibmpCvlFCgWJxcXl+UUpSjpKJZm5QFUGegYG5rUApmB0WFIAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:17 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=ushkqmr1t9bhu636sohm3qjdmg; expires=Thu, 05-Nov-2020 13:39:17 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjUw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskqeeWWJOZkpCqXF
+        qUV5ibmpCvlFCgWJxcXl+UUpSjpKJZm5QFUGegYGprUAJAJCalIAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:17 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=tpi619vqreehocgqhe8b0fe9fe; expires=Thu, 05-Nov-2020 13:39:17 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/tests/fixtures/test_connection_success.yml
+++ b/tests/fixtures/test_connection_success.yml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3NSwrCMBQF0K3IHSdyE8WSN1ecCf4GTqQkb1DFVpoUC6V7tws4nAmxSwrxpEEe
+        YtScIaUf1CDVpYZMKN1bWwjy3Yb983R8nePt0R402fF32V0DDHT8Nr0uEp6e1jnL7cpTNkFchdmg
+        NJ9l4Zqs5j/I4HhEdAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:17 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=1a4mihglov6rns984mldh8nhdi; expires=Thu, 05-Nov-2020 13:39:17 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_controllers.yml
+++ b/tests/fixtures/test_controllers.yml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3NSwrCMBQF0K3IHSdyE0XMmyvOBH8DJ1KSN6jFVpoUC6V7tws4nAmxSwrxpEEe
+        YtScIaUf1CBVpYJMKF2jLQT5YcPhdT69L/H+bI+a7Pi77m4BBjp+614XCU9P65zlduUpmyBuj9mg
+        1J9l4ZoM8x+T/nkcdAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:18 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=9q9sne55trqrr44rjm7qg0c9p8; expires=Thu, 05-Nov-2020 13:39:18 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: OPTIONS
+    uri: https://ipam.example.org/api/ansible//
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA42SsXLDIAyG30UzV3Pt5q1P0aHuoIDccsGQE3IWn9892HV9IXfBXRik7xP8wAQm
+        WoL2VWsFaTSGUoJWeCQFFgWhneBCPLiUXAy5BR/shEBlLwhH74lz9XMCJp+7iYysoIIfpj5XugYv
+        Li8huZOnrvkjugZmtWvjKZDUrF+gkPro7bL7U2kDCgmt5ZyRKtqOFOLVYy3W0i557ms49wUdcKBE
+        fK3mkRh9PtQdW16iwfD+TaF2j9uIBcUVLSb4aPDg+bYBO1n4jOZ87K7UQ3r5R2opnLV8aMH8NSsQ
+        N+Q/rl+0fptvrSqZ5PICAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:18 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=lj6n8k9rom3l1ee592u2mqk68g; expires=Thu, 05-Nov-2020 13:39:18 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_create_nameserver.yml
+++ b/tests/fixtures/test_create_nameserver.yml
@@ -1,0 +1,156 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/?filter_by=name&filter_value=my+dns
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++QpFqcWlOSXF
+        ChppmTklqUUKiQUFOZmpKZpKOkolmblARQZ6BgYmtQBnBaDXUQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:18 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=gdlp24pbt511hh0qpvrl0qr866; expires=Thu, 05-Nov-2020 13:39:18 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: name=my+dns&namesrv1=127.0.01&permissions=1
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '43'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/tools/nameservers
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3MMQ6AIBBE0auQqYkBCwpug8sUmiAJu9gY7y7dL17+C+mVyHuIHjpFqIpsY9Lj
+        rMhIER61WFl9l0bleDjU9eOimJPBYqzL2NnWJ2whpO8HeBwzH1YAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:18 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Location:
+      - /api/ansible/tools/nameservers/61/
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=73q0lsgbjds8kvj38do201ivss; expires=Thu, 05-Nov-2020 13:39:18 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/?filter_by=name&filter_value=my+dns
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAy3MwQrCMBCE4VeROYeSFFHI2bcQDyG7h4UmLdmtIKXvboIe5+djDuSVGHH23kH3
+        nFkV0drODpQsIT4PCCHiFuBQU+kY5XOhqv+t7R16C/N98pMfilhzk81krYh1XxaHjVsR1V502I6Y
+        xB7J+CfOl4PJOO8f/np+ARgWkdGYAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:18 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=cqqbcpi64j5qih7h3092jvs6a4; expires=Thu, 05-Nov-2020 13:39:18 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_create_section.yml
+++ b/tests/fixtures/test_create_section.yml
@@ -1,0 +1,157 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/foobar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++SUKbvmleSlK
+        OkolmblAIQM9AwPjWgChqv3nPwAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:20 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=u972h9e9ibpvh8qd1vc9sfisk3; expires=Thu, 05-Nov-2020 13:39:20 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: name=foobar&description=new+section&permissions=%7B%223%22%3A%221%22%2C%222%22%3A%222%22%7D
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/sections
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw2KQQrAIAwEv1L2LCV6Er/RF0gMJQcraDyV/r25DTPzgkcTlEQxYG1mWQvF5paA
+        7lxvj7iETcdz8JRq0hCgzXVM5Gja/aGTKH8/ecv1YU8AAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:20 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Location:
+      - /api/ansible/sections/120/
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=ctsoadk12nh0sahhqvphka90nm; expires=Thu, 05-Nov-2020 13:39:20 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/foobar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02PzWrEIBRGX6V8aykms3NXGLpqp9BAV24cvW2FRAevMpSQd6/aBLoRz+H+fHeF
+        jY6gRikFuFhLzFA5FRJwJhuoFd5BYRglBIJZajE+Y7yaVNkR2+Rv2cdQdaD7A5PtJLAYzpSmnRVa
+        /43S4pmrqFuwapw0lMagITTG/q/vVis5J2/zaw+HoYlyDZTfkqPkwxdUKPMsEBsfQM7ns8l0MH/H
+        +9TbjhlVfLw8XfY0Hd+f/9FUasK2Jsw/uz5fpr95m0D27Xz5KOVp+wVsLmGDOgEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:20 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=tmmp6ucdm2qdbk599ooahve4rn; expires=Thu, 05-Nov-2020 13:39:20 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_create_vlan.yml
+++ b/tests/fixtures/test_create_vlan.yml
@@ -1,0 +1,156 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlan/?filter_by=name&filter_value=my+vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++QpFqcWlOSXF
+        ChppmTklqUUKiQUFOZmpKZpKOkolmblARQZ6BgYmtQBnBaDXUQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:21 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=s1nmu0691tk0g69200bm4jr7is; expires=Thu, 05-Nov-2020 13:39:21 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: name=my+vlan&number=1337
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw1FEqLk1OTi0uVrIqKSpN1VHKBbIT04GSSmE5iXkKyUWpiSWp
+        KUo6SpkpQDFTMyCrJDMXKG+gZ2BoUgsAL5ZeVEsAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:22 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Location:
+      - /api/ansible/vlans/56/
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=u9h67bd05snjmdra8brvr1db8p; expires=Thu, 05-Nov-2020 13:39:22 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlan/?filter_by=name&filter_value=my+vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMywpCIRRFfyX2WMKSChw36Rsi4qRnIPgIPQZxuf+ecmm41n4scMUz7FFrhdad
+        49ZgpXZW8CQEe1/wiZRvHhanM4YuicLGh4GZ0tgjfXezNkVPL64zNeYy+9xcDW8JJcPmHqMC+yBX
+        Ev6z601K4voMflPrQ0HCPNZ7rc36A8HHFdqnAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:22 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=sbhtfu1s680ifh9oennpmqlk29; expires=Thu, 05-Nov-2020 13:39:22 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_custom_user_agent.yml
+++ b/tests/fixtures/test_custom_user_agent.yml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3NSwrCMBQF0K3IHSdyE0XJmyvOBH8DJ1KSN6jFVpoUC6V7tws4nAmxSwrxpEEe
+        YtScIaUf1CBVpYJMKF2jLQT5YcPhdT69L/H+bI+a7Pi77m4BBjp+614XCU9P65zlduUpmyBuj9mg
+        1J9l4ZoM8x9GzfvadAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:17 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=e1gebg3pb3oif2acjd0fghj8eq; expires=Thu, 05-Nov-2020 13:39:17 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_delete_nameserver.yml
+++ b/tests/fixtures/test_delete_nameserver.yml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/?filter_by=name&filter_value=my+dns
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02NuwrDMAxFfyVodoLkhpZ47l+UDsbS4CEPLKcQQv69MnToeI/O1T0hrSwQPKID
+        3VMSVQi17OKAY40QXidkhgB3AgdLnE2G+eh40V/W8iFj5B8DDtgsFk0lbzWvix3+UheZhc3YpMxZ
+        1ZC2qhHhXJ+xtu8ePfZEPY4djeE2BZrgejuouY3bBo7XFxEdJfy4AAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:19 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=7l14k21eoh6avj4826qq4237ub; expires=Thu, 05-Nov-2020 13:39:19 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: DELETE
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/61
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3KMQqAMBBE0avI1EEWK8lt4mYQxRjIbmzEu5vuwf8vtGYiLiIB1lVphuitM6AM
+        p31E3GmY7WGzqW4n1afMi86MAD/KeGQWWb8fXwNW+U8AAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:19 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=11beq4uj815021pn69isi00aqj; expires=Thu, 05-Nov-2020 13:39:19 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/?filter_by=name&filter_value=my+dns
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++QpFqcWlOSXF
+        ChppmTklqUUKiQUFOZmpKZpKOkolmblARQZ6BgbGtQCgk+GYUQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:19 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=i2bq7mj87ths2l2s1bhkc6ejkl; expires=Thu, 05-Nov-2020 13:39:19 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/fixtures/test_delete_section.yml
+++ b/tests/fixtures/test_delete_section.yml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/foobar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02QT2sDIRTEv0qYsym6m0u9FUJPaQpd6GkvRl9bYVeDfwhl2e9etRvIRZwfz5l5
+        LtDeEGTHOUPMWlOMkClkYjAqKcgF1kBCdBwMTs1lGF/eX1Qo2lDUwV6T9a5gR7fdI2GYVUwUBtLb
+        RPW4UphtjAWUJCwj+hFyhBjBRnTtXs61TMYUrE5vrSBEBfniKL0HQ8G6b0iXp4nBV30XZGw6qlRf
+        dLzjeyH2/LATB9k/y7ZC/PG3ofncTQv4PL2ct3pNfrw+qCGXyjXXTb8bPp6H/8CVIdn6J/yJ8379
+        A+B1YcBPAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:21 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=3siavl1rat5e2il2l4p2lsppml; expires=Thu, 05-Nov-2020 13:39:21 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: DELETE
+    uri: https://ipam.example.org/api/ansible/sections/120
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw0FEqLk1OTi0uVrIqKSpN1VEqycwFyhjoGRhY1gIAFM+iSSgA
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:21 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=us0lrl4u86k3us4v269rbbo7pb; expires=Thu, 05-Nov-2020 13:39:21 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/foobar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++SUKbvmleSlK
+        OkolmblAIQM9AwPjWgChqv3nPwAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:21 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=aqdhu4tksfbctcbmn6bj94iar7; expires=Thu, 05-Nov-2020 13:39:21 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/fixtures/test_delete_vlan.yml
+++ b/tests/fixtures/test_delete_vlan.yml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlan/?filter_by=name&filter_value=my+vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02NywrCMBBFf6XMupVJUhWz7sZvEJGYzCLQJJKHIKX/7gQ3Lu+Zc+duYJMj0BJx
+        hNKspVJA19xoBGeqAX3b4L2aeHWg4XgCxikY/8uCYzSB+xA+Q9c6aOFJuV+VOnefis3+VX2KDP/S
+        YJwjxwY5XxdT+xuJEichJpwHMWt10VKyYFupKVB+eF6NbV33+wjV92E8IKr9Cz8ztxHHAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:23 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=6h59vtuj0078khf46le2ccko4i; expires=Thu, 05-Nov-2020 13:39:23 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: DELETE
+    uri: https://ipam.example.org/api/ansible/vlan/56
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw0FEqLk1OTi0uVrIqKSpN1VHKBbIT04GSSmE5iXkKKak5qSWp
+        KUo6SiWZuUBRAz0DY+NaAPBnWSBBAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:23 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=athjrkehau5kbh4t3j4jqnjg28; expires=Thu, 05-Nov-2020 13:39:23 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlan/?filter_by=name&filter_value=my+vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++QpFqcWlOSXF
+        ChppmTklqUUKiQUFOZmpKZpKOkolmblARQZ6BgbGtQCgk+GYUQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:23 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=kt23cgn90d8o8f67l5i2lvbp3h; expires=Thu, 05-Nov-2020 13:39:23 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/fixtures/test_invalid_credentials_exception.yml
+++ b/tests/fixtures/test_invalid_credentials_exception.yml
@@ -1,0 +1,100 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjUw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskqeeWWJOZkpCqXF
+        qUV5ibmpCvlFCgWJxcXl+UUpSjpKJZm5QFUGegYGprUAJAJCalIAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:23 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=12fjtooegcscoqu4rq58j3uc8j; expires=Thu, 05-Nov-2020 13:39:23 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 500
+      message: Internal Server Error
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjUw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskqeeWWJOZkpCqXF
+        qUV5ibmpCvlFCgWJxcXl+UUpSjpKJZm5QFUGegYG5rUApmB0WFIAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:24 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=juok1n1c6dfs09t09iqc394pmn; expires=Thu, 05-Nov-2020 13:39:24 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 500
+      message: Internal Server Error
+version: 1

--- a/tests/fixtures/test_invalid_syntax_exception.yml
+++ b/tests/fixtures/test_invalid_syntax_exception.yml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/faulty%20data/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskqeeWWJOZkpCokF
+        BTmZyYklmfl5CpkpSjpKJZm5QHmDWgBOB7BhSAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - close
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:23 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=0r1j63842r87c6skgjhb7u27r5; expires=Thu, 05-Nov-2020 13:39:23 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/fixtures/test_search_existing_section.yml
+++ b/tests/fixtures/test_search_existing_section.yml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/?filter_by=name&filter_value=IPv6&filter_match=full
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02QQUvEMBCF/0p557Bku7CH3IRFEHQVC16Mh5iMa6BNliRVpPS/O6kteAnzPl7e
+        PGaCjY6gWikF8mgt5QxV0kgCzhQD9TrBOyi0EAhmYC/unr6OrBxlm/y1+BgYdmTr1HzE1FRDY5xL
+        nEaZrYPJhdJqYbNkdqU0+JwZ8EZMGgcNpbHXEBrtMvM7szOX5G15WIpiX8H4Hqg8JkfJhwtUGPte
+        IFa9CXK+nEyhTefP+N0t37YMBi/3N+e1zSKfb/+pbuSGdU3of1Z8Ond/efObQPH1GHIn5WH+BWf2
+        6dBHAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:24 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=b27c0o91pp5q3irgqisonqv0cq; expires=Thu, 05-Nov-2020 13:39:24 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_search_not_existing_section.yml
+++ b/tests/fixtures/test_search_not_existing_section.yml
@@ -1,0 +1,51 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/?filter_by=name&filter_value=non_existing_section
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjEw0VEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++QpFqcWlOSXF
+        ChppmTklqUUKiQUFOZmpKZpKOkolmblARQZ6BgbGtQCgk+GYUQAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:24 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=6bi0finga1plqmvpduu8bvv8n1; expires=Thu, 05-Nov-2020 13:39:24 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/tests/fixtures/test_subnet_not_found.yml
+++ b/tests/fixtures/test_subnet_not_found.yml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3NwQqCQBAG4FeJ/7wb46TBzr3oJlh66BKyOweTNNyVBPHd8wE+vhV+DAphIoM4
+        e68xQtI0q0FoUwtZkcZeBwhiY93lVd7ela+fw1WDXX7388PBQJdvN+kuwcRks8xSfmCSkxMusBmk
+        7rMvdCRy2x/jgEHkdAAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:25 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=a6ojmiaffevmabg796nqrjsgpm; expires=Thu, 05-Nov-2020 13:39:25 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/subnets/cidr/10.0.0.0/24
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw0FEqLk1OTi0uVrJKS8wpTtVRygVyEtOBskp++QrFpUl5qSXF
+        Cmn5pXkpSjpKJZm5QBkDPQMDk1oA71UZV0YAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:25 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=hasdlesqn44qq2g3rtejagie0t; expires=Thu, 05-Nov-2020 13:39:25 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_update_nameserver.yml
+++ b/tests/fixtures/test_update_nameserver.yml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/?filter_by=name&filter_value=my+dns
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAy3MwQrCMBCE4VeROYeSVFDI2bcQDyG7h4UmLdmtIKXvboIe5+djDuSVGHH23kH3
+        nFkV0drODpQsIT4PCCHiFuBQU+kY5XOhqv+t7R16C/N98pMfilhzk81krYh1XxaHjVsR1V502I6Y
+        xB7J+CfOl4PJOO8f/np+Ad+A0J6YAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:18 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=3mkpm8btajp5d0vpt544r1et22; expires=Thu, 05-Nov-2020 13:39:18 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: name=my+dns&namesrv1=127.0.01&permissions=1&description=description+added
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: PATCH
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/61
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAw3KMQqAMAxG4auUfy4SHBx6m5oGsVArTeoi3t1sH7z3gnsRpJUoQiezqCLZmBLR
+        3PnwiCu7ZTwyNPS9CluYd8kmBRF2Nn9oIdq+H8lOfmtPAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:19 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=usaqfp7b3dfj8na4qjflead40v; expires=Thu, 05-Nov-2020 13:39:19 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/nameservers/?filter_by=name&filter_value=my+dns
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02NuwrDMAxFfyVodoLkhpZ47l+UDsbS4CEPLKcQQv69MnToeI/O1T0hrSwQPKID
+        3VMSVQi17OKAY40QXidkhgB3AgdLnE2G+eh40V/W8iFj5B8DDtgsFk0lbzWvix3+UheZhc3YpMxZ
+        1ZC2qhHhXJ+xtu8ePfZEPY4djeE2BZrgejuouY3bBo7XFxEdJfy4AAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:19 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=qn56s4bbgf21um64qihae9of7q; expires=Thu, 05-Nov-2020 13:39:19 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_update_section.yml
+++ b/tests/fixtures/test_update_section.yml
@@ -1,0 +1,158 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/foobar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02PzWrEIBRGX6V8aykms3NXGLpqp9BAV24cvW2FRAevMpSQd6/aBLoRz+H+fHeF
+        jY6gRikFuFhLzFA5FRJwJhuoFd5BYRglBIJZajE+Y7yaVNkR2+Rv2cdQdaD7A5PtJLAYzpSmnRVa
+        /43S4pmrqFuwapw0lMagITTG/q/vVis5J2/zaw+HoYlyDZTfkqPkwxdUKPMsEBsfQM7ns8l0MH/H
+        +9TbjhlVfLw8XfY0Hd+f/9FUasK2Jsw/uz5fpr95m0D27Xz5KOVp+wVsLmGDOgEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:20 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=r321svks2vfkrcsv5c95hvd8n0; expires=Thu, 05-Nov-2020 13:39:20 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: name=foobar&description=new+description&permissions=%7B%223%22%3A%221%22%2C%222%22%3A%222%22%7D
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '95'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: PATCH
+    uri: https://ipam.example.org/api/ansible/sections/120
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw0FEqLk1OTi0uVrIqKSpN1VEqycwFyhjoGRhY1AIAVf65UCgA
+        AAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:20 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=415jp3h1tfelf091m2lr8h9f0e; expires=Thu, 05-Nov-2020 13:39:20 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/foobar
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02QT2sDIRTEv0qYsym6m0u9FUJPaQpd6GkvRl9bYVeDfwhl2e9etRvIRZwfz5l5
+        LtDeEGTHOUPMWlOMkClkYjAqKcgF1kBCdBwMTs1lGF/eX1Qo2lDUwV6T9a5gR7fdI2GYVUwUBtLb
+        RPW4UphtjAWUJCwj+hFyhBjBRnTtXs61TMYUrE5vrSBEBfniKL0HQ8G6b0iXp4nBV30XZGw6qlRf
+        dLzjeyH2/LATB9k/y7ZC/PG3ofncTQv4PL2ct3pNfrw+qCGXyjXXTb8bPp6H/8CVIdn6J/yJ8379
+        A+B1YcBPAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:21 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=8j6dnkrlrd2h5daevlpfgno2cq; expires=Thu, 05-Nov-2020 13:39:21 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_update_vlan.yml
+++ b/tests/fixtures/test_update_vlan.yml
@@ -1,0 +1,155 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlan/?filter_by=name&filter_value=my+vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAzWMywpCIRRFfyX2WMKSChw36Rsi4qRnIPgIPQZxuf+ecmm41n4scMUz7FFrhdad
+        49ZgpXZW8CQEe1/wiZRvHhanM4YuicLGh4GZ0tgjfXezNkVPL64zNeYy+9xcDW8JJcPmHqMC+yBX
+        Ev6z601K4voMflPrQ0HCPNZ7rc36A8HHFdqnAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:22 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=sghlrtapkemj4kunholta7eb0e; expires=Thu, 05-Nov-2020 13:39:22 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: name=my+vlan&number=1337&vlanId=56&description=description+added
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '64'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.24.0
+    method: PATCH
+    uri: https://ipam.example.org/api/ansible/vlan/56
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSs5PSVWyMjIw0FEqLk1OTi0uVrIqKSpN1VHKBbIT04GSSmE5iXkKpQUpiSWp
+        KUo6SiWZuUBRAz0DA7NaAPRNw1NBAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:22 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=k3qf80i0hqkm6dulhc4qp4308r; expires=Thu, 05-Nov-2020 13:39:22 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlan/?filter_by=name&filter_value=my+vlan
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA02NywrCMBBFf6XMupVJUhWz7sZvEJGYzCLQJJKHIKX/7gQ3Lu+Zc+duYJMj0BJx
+        hNKspVJA19xoBGeqAX3b4L2aeHWg4XgCxikY/8uCYzSB+xA+Q9c6aOFJuV+VOnefis3+VX2KDP/S
+        YJwjxwY5XxdT+xuJEichJpwHMWt10VKyYFupKVB+eF6NbV33+wjV92E8IKr9Cz8ztxHHAAAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 04 Nov 2020 13:39:22 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1c
+      Set-Cookie:
+      - phpipam=jjkpb1ph3v58fb2gl84154mhu0; expires=Thu, 05-Nov-2020 13:39:22 GMT;
+        Max-Age=86400; path=/; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_cases/api_connection.py
+++ b/tests/test_cases/api_connection.py
@@ -4,7 +4,7 @@ import pytest
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam.core.exceptions import PHPyPAMInvalidCredentials
 
 

--- a/tests/test_cases/api_connection.py
+++ b/tests/test_cases/api_connection.py
@@ -1,9 +1,12 @@
 """Tests to check connection to API."""
 import phpypam
 import pytest
+import vcr
 import yaml
 
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
 from phpypam.core.exceptions import PHPyPAMInvalidCredentials
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
@@ -17,6 +20,11 @@ connection_params = dict(
 )
 
 
+@vcr.use_cassette(cassette_name('test_connection_success'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_connection_success():
     """Test whether a connection to API can be done."""
     pi = phpypam.api(**connection_params)
@@ -27,6 +35,11 @@ def test_connection_success():
     assert len(token) == 24
 
 
+@vcr.use_cassette(cassette_name('test_connection_failure'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_connection_failure():
     """Test faulty connection.
 
@@ -43,6 +56,11 @@ def test_connection_failure():
     pytest.raises(PHPyPAMInvalidCredentials, phpypam.api, **connection_kwargs)
 
 
+@vcr.use_cassette(cassette_name('test_custom_user_agent'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_custom_user_agent():
     """Test to set custom user-agent header.
 

--- a/tests/test_cases/controllers.py
+++ b/tests/test_cases/controllers.py
@@ -1,14 +1,8 @@
 """Test controller method."""
-import phpypam
 import pytest
 import vcr
-import yaml
 
 from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
-
-
-with open('tests/vars/server.yml') as c:
-    server = yaml.safe_load(c)
 
 
 @vcr.use_cassette(cassette_name('test_controllers'),
@@ -16,15 +10,7 @@ with open('tests/vars/server.yml') as c:
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_controllers():
+def test_controllers(pi):
     """Test if controllers method returns correct datatype."""
-    pi = phpypam.api(
-        url=server['url'],
-        app_id=server['app_id'],
-        username=server['username'],
-        password=server['password'],
-        ssl_verify=True
-    )
-
     controllers = pi.controllers()
     assert isinstance(controllers, set)

--- a/tests/test_cases/controllers.py
+++ b/tests/test_cases/controllers.py
@@ -1,8 +1,7 @@
 """Test controller method."""
-import pytest
 import vcr
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 
 
 @vcr.use_cassette(cassette_name('test_controllers'),

--- a/tests/test_cases/controllers.py
+++ b/tests/test_cases/controllers.py
@@ -1,11 +1,21 @@
 """Test controller method."""
 import phpypam
+import pytest
+import vcr
 import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
 
+@vcr.use_cassette(cassette_name('test_controllers'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_controllers():
     """Test if controllers method returns correct datatype."""
     pi = phpypam.api(

--- a/tests/test_cases/ensure_nameserver.py
+++ b/tests/test_cases/ensure_nameserver.py
@@ -11,14 +11,6 @@ from tests.conftest import filter_request_uri, filter_response, cassette_name, F
 from phpypam import PHPyPAMEntityNotFoundException
 
 
-pi = phpypam.api(
-    url=server['url'],
-    app_id=server['app_id'],
-    username=server['username'],
-    password=server['password'],
-    ssl_verify=True
-)
-
 my_nameserver = dict(
     name='my dns',
     namesrv1='127.0.01',
@@ -31,7 +23,7 @@ my_nameserver = dict(
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_create_nameserver():
+def test_create_nameserver(pi):
     """Test to create a new nameserver.
 
     Create a nameserver if it doesn't exists
@@ -50,7 +42,7 @@ def test_create_nameserver():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_update_nameserver():
+def test_update_nameserver(pi):
     """Test to update an existing nameserver.
 
     Update one field of an existing nameserver
@@ -70,7 +62,7 @@ def test_update_nameserver():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_delete_nameserver():
+def test_delete_nameserver(pi):
     """Test to delete an existing nameserver.
 
     Delete the nameserver which we created before

--- a/tests/test_cases/ensure_nameserver.py
+++ b/tests/test_cases/ensure_nameserver.py
@@ -1,11 +1,13 @@
 """Tests to check funtionallity of section handling."""
 import phpypam
 import pytest
+import vcr
 import yaml
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 
@@ -24,8 +26,13 @@ my_nameserver = dict(
 )
 
 
+@vcr.use_cassette(cassette_name('test_create_nameserver'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_create_nameserver():
-    """Test to create a new nameserver
+    """Test to create a new nameserver.
 
     Create a nameserver if it doesn't exists
     """
@@ -38,6 +45,11 @@ def test_create_nameserver():
     assert entity is not None
 
 
+@vcr.use_cassette(cassette_name('test_update_nameserver'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_update_nameserver():
     """Test to update an existing nameserver.
 
@@ -53,6 +65,11 @@ def test_update_nameserver():
     assert entity[0]['description'] == my_nameserver['description']
 
 
+@vcr.use_cassette(cassette_name('test_delete_nameserver'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_delete_nameserver():
     """Test to delete an existing nameserver.
 

--- a/tests/test_cases/ensure_nameserver.py
+++ b/tests/test_cases/ensure_nameserver.py
@@ -1,5 +1,4 @@
 """Tests to check funtionallity of section handling."""
-import phpypam
 import pytest
 import vcr
 import yaml
@@ -7,7 +6,7 @@ import yaml
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 

--- a/tests/test_cases/ensure_section.py
+++ b/tests/test_cases/ensure_section.py
@@ -11,14 +11,6 @@ from phpypam import PHPyPAMEntityNotFoundException
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
-pi = phpypam.api(
-    url=server['url'],
-    app_id=server['app_id'],
-    username=server['username'],
-    password=server['password'],
-    ssl_verify=True
-)
-
 my_section = dict(
     name='foobar',
     description='new section',
@@ -31,7 +23,7 @@ my_section = dict(
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_create_section():
+def test_create_section(pi):
     """Test to create a new section.
 
     Create a section if it doesn't exists
@@ -51,7 +43,7 @@ def test_create_section():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_update_section():
+def test_update_section(pi):
     """Test to update an existing section.
 
     Update one field of an existing section.
@@ -70,7 +62,7 @@ def test_update_section():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_delete_section():
+def test_delete_section(pi):
     """Test to delete an existing section.
 
     Delete one field of an existing section.

--- a/tests/test_cases/ensure_section.py
+++ b/tests/test_cases/ensure_section.py
@@ -1,13 +1,15 @@
 """Tests to check funtionallity of section handling."""
 import phpypam
 import pytest
+import vcr
 import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from phpypam import PHPyPAMEntityNotFoundException
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
-
-from phpypam import PHPyPAMEntityNotFoundException
-
 
 pi = phpypam.api(
     url=server['url'],
@@ -24,6 +26,11 @@ my_section = dict(
 )
 
 
+@vcr.use_cassette(cassette_name('test_create_section'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_create_section():
     """Test to create a new section.
 
@@ -39,6 +46,11 @@ def test_create_section():
     assert entity is not None
 
 
+@vcr.use_cassette(cassette_name('test_update_section'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_update_section():
     """Test to update an existing section.
 
@@ -53,7 +65,11 @@ def test_update_section():
     assert entity['description'] == my_section['description']
 
 
-# @ pytest.mark.xpass(raises=PHPyPAMEntityNotFoundException)
+@vcr.use_cassette(cassette_name('test_delete_section'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_delete_section():
     """Test to delete an existing section.
 

--- a/tests/test_cases/ensure_section.py
+++ b/tests/test_cases/ensure_section.py
@@ -1,10 +1,9 @@
 """Tests to check funtionallity of section handling."""
-import phpypam
 import pytest
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 

--- a/tests/test_cases/ensure_vlan.py
+++ b/tests/test_cases/ensure_vlan.py
@@ -11,14 +11,6 @@ from phpypam import PHPyPAMEntityNotFoundException
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
-pi = phpypam.api(
-    url=server['url'],
-    app_id=server['app_id'],
-    username=server['username'],
-    password=server['password'],
-    ssl_verify=True
-)
-
 my_vlan = dict(
     name='my vlan',
     number='1337',
@@ -30,7 +22,7 @@ my_vlan = dict(
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_create_vlan():
+def test_create_vlan(pi):
     """Test to create a new vlan.
 
     Create a vlan if it doesn't exists
@@ -49,7 +41,7 @@ def test_create_vlan():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_update_vlan():
+def test_update_vlan(pi):
     """Test to update an existing vlan.
 
     Update one field of an existing vlan
@@ -72,7 +64,7 @@ def test_update_vlan():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_delete_vlan():
+def test_delete_vlan(pi):
     """Test to delete an existing vlan.
 
     Delete vlan which we created before

--- a/tests/test_cases/ensure_vlan.py
+++ b/tests/test_cases/ensure_vlan.py
@@ -1,13 +1,15 @@
 """Tests to check funtionallity of vlan handling."""
 import phpypam
 import pytest
+import vcr
 import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from phpypam import PHPyPAMEntityNotFoundException
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
-
-from phpypam import PHPyPAMEntityNotFoundException
-
 
 pi = phpypam.api(
     url=server['url'],
@@ -23,6 +25,11 @@ my_vlan = dict(
 )
 
 
+@vcr.use_cassette(cassette_name('test_create_vlan'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_create_vlan():
     """Test to create a new vlan.
 
@@ -37,6 +44,11 @@ def test_create_vlan():
     assert entity is not None
 
 
+@vcr.use_cassette(cassette_name('test_update_vlan'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_update_vlan():
     """Test to update an existing vlan.
 
@@ -55,6 +67,11 @@ def test_update_vlan():
     assert entity[0]['description'] == my_vlan['description']
 
 
+@vcr.use_cassette(cassette_name('test_delete_vlan'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_delete_vlan():
     """Test to delete an existing vlan.
 

--- a/tests/test_cases/ensure_vlan.py
+++ b/tests/test_cases/ensure_vlan.py
@@ -1,10 +1,9 @@
 """Tests to check funtionallity of vlan handling."""
-import phpypam
 import pytest
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 

--- a/tests/test_cases/force_exceptions.py
+++ b/tests/test_cases/force_exceptions.py
@@ -1,13 +1,15 @@
 """Test exceptions."""
-import pytest
 import phpypam
+import pytest
+import vcr
 import yaml
 
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
 from phpypam.core.exceptions import PHPyPAMInvalidCredentials, PHPyPAMInvalidSyntax
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
-
 
 connection_params = dict(
     url=server['url'],
@@ -18,6 +20,11 @@ connection_params = dict(
 )
 
 
+@vcr.use_cassette(cassette_name('test_invalid_syntax_exception'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_invalid_syntax_exception():
     """Test invalid syntax exception.
 
@@ -31,6 +38,11 @@ def test_invalid_syntax_exception():
     connection_params.update({'app_id': server['app_id']})
 
 
+@vcr.use_cassette(cassette_name('test_invalid_credentials_exception'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_invalid_credentials_exception():
     """Test invalid credentials exception.
 

--- a/tests/test_cases/force_exceptions.py
+++ b/tests/test_cases/force_exceptions.py
@@ -4,7 +4,7 @@ import pytest
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam.core.exceptions import PHPyPAMInvalidCredentials, PHPyPAMInvalidSyntax
 
 

--- a/tests/test_cases/search_address.py
+++ b/tests/test_cases/search_address.py
@@ -1,15 +1,22 @@
 """Test search for address."""
-import pytest
 import phpypam
-import json
+import pytest
+import vcr
 import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from phpypam import PHPyPAMEntityNotFoundException
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
-from phpypam import PHPyPAMEntityNotFoundException
 
-
+@vcr.use_cassette(cassette_name('test_address_not_found'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_address_not_found():
     """Test address not found execption."""
     pi = phpypam.api(

--- a/tests/test_cases/search_address.py
+++ b/tests/test_cases/search_address.py
@@ -1,10 +1,9 @@
 """Test search for address."""
-import phpypam
 import pytest
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 

--- a/tests/test_cases/search_address.py
+++ b/tests/test_cases/search_address.py
@@ -17,18 +17,9 @@ with open('tests/vars/server.yml') as c:
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_address_not_found():
+def test_address_not_found(pi):
     """Test address not found execption."""
-    pi = phpypam.api(
-        url=server['url'],
-        app_id=server['app_id'],
-        username=server['username'],
-        password=server['password'],
-        ssl_verify=True
-    )
-
     addr = '10.10.0.4'
-
     search_kwargs = dict(controller='addresses', controller_path='search/' + addr)
 
     pytest.raises(PHPyPAMEntityNotFoundException, pi.get_entity, **search_kwargs)

--- a/tests/test_cases/search_section_by_name.py
+++ b/tests/test_cases/search_section_by_name.py
@@ -11,21 +11,13 @@ from phpypam import PHPyPAMEntityNotFoundException
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
-pi = phpypam.api(
-    url=server['url'],
-    app_id=server['app_id'],
-    username=server['username'],
-    password=server['password'],
-    ssl_verify=True
-)
-
 
 @vcr.use_cassette(cassette_name('test_search_not_existing_section'),
                   filter_headers=FILTER_REQUEST_HEADERS,
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_search_not_existing_section():
+def test_search_not_existing_section(pi):
     """Search for non existing section.
 
     Search for a non existign section and get NotFound exception
@@ -40,7 +32,7 @@ def test_search_not_existing_section():
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_search_existing_section():
+def test_search_existing_section(pi):
     """Search for existing section.
 
     Search for an existing section

--- a/tests/test_cases/search_section_by_name.py
+++ b/tests/test_cases/search_section_by_name.py
@@ -1,10 +1,9 @@
 """Tests to check section search via url parameters."""
-import phpypam
 import pytest
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 

--- a/tests/test_cases/search_section_by_name.py
+++ b/tests/test_cases/search_section_by_name.py
@@ -1,13 +1,15 @@
 """Tests to check section search via url parameters."""
 import phpypam
 import pytest
+import vcr
 import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from phpypam import PHPyPAMEntityNotFoundException
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
-
-from phpypam import PHPyPAMEntityNotFoundException
-
 
 pi = phpypam.api(
     url=server['url'],
@@ -18,6 +20,11 @@ pi = phpypam.api(
 )
 
 
+@vcr.use_cassette(cassette_name('test_search_not_existing_section'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_search_not_existing_section():
     """Search for non existing section.
 
@@ -28,6 +35,11 @@ def test_search_not_existing_section():
     pytest.raises(PHPyPAMEntityNotFoundException, pi.get_entity, **search_kwargs)
 
 
+@vcr.use_cassette(cassette_name('test_search_existing_section'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_search_existing_section():
     """Search for existing section.
 

--- a/tests/test_cases/search_subnet.py
+++ b/tests/test_cases/search_subnet.py
@@ -17,18 +17,9 @@ with open('tests/vars/server.yml') as c:
                   before_record_request=filter_request_uri,
                   before_recorde_response=filter_response
                   )
-def test_subnet_not_found():
+def test_subnet_not_found(pi):
     """Test subnet not found exeption."""
-    pi = phpypam.api(
-        url=server['url'],
-        app_id=server['app_id'],
-        username=server['username'],
-        password=server['password'],
-        ssl_verify=True
-    )
-
     cidr = '10.0.0.0/24'
-
     search_kwargs = dict(controller='subnets', controller_path='cidr/' + cidr)
 
     pytest.raises(PHPyPAMEntityNotFoundException, pi.get_entity, **search_kwargs)

--- a/tests/test_cases/search_subnet.py
+++ b/tests/test_cases/search_subnet.py
@@ -1,15 +1,22 @@
 """Test search for subnet."""
 import pytest
 import phpypam
-import json
+import vcr
 import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from phpypam import PHPyPAMEntityNotFoundException
+
 
 with open('tests/vars/server.yml') as c:
     server = yaml.safe_load(c)
 
-from phpypam import PHPyPAMEntityNotFoundException
 
-
+@vcr.use_cassette(cassette_name('test_subnet_not_found'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response
+                  )
 def test_subnet_not_found():
     """Test subnet not found exeption."""
     pi = phpypam.api(

--- a/tests/test_cases/search_subnet.py
+++ b/tests/test_cases/search_subnet.py
@@ -1,10 +1,9 @@
 """Test search for subnet."""
 import pytest
-import phpypam
 import vcr
 import yaml
 
-from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS, FILTER_RESPONSE_HEADERS
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
 from phpypam import PHPyPAMEntityNotFoundException
 
 


### PR DESCRIPTION
- Add modules needed for recording and replaying
- Record tests for replay in CI
- Add CI workflow
- create a valid server.xml before running tests
- Add `phpypam.api` as fixture for most tests
- remove unused imports
