### PR TITLE
Added not-found error message for hostname search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 ### Fixes
+* fix #48 - raise PHPyPAMEntityNotFoundException if searching for non existing host
 
 ### Breaks
 

--- a/phpypam/core/exceptions.py
+++ b/phpypam/core/exceptions.py
@@ -7,6 +7,17 @@ class PHPyPAMException(Exception):
     This exception is raised if anythings in :class:`phpypam.api` doesn't work out.
     """
 
+    _NOT_FOUND_MESSAGES = {
+        'No subnets found',
+        'Address not found',
+        'Vlan not found',
+        'No vrfs configured',
+        'No devices configured',
+        'No results (filter applied)',
+        'No objects found',
+        'Hostname not found'
+    }
+
     def __init__(self, *args, code=None, message=None):
         """Generate PHPyPAMException.
 
@@ -24,18 +35,7 @@ class PHPyPAMException(Exception):
         self._code = code
         self._message = message
 
-        _NOT_FOUND_MESSAGES = {
-            'No subnets found',
-            'Address not found',
-            'Vlan not found',
-            'No vrfs configured',
-            'No devices configured',
-            'No results (filter applied)',
-            'No objects found',
-            'Hostname not found'
-        }
-
-        if (self._code == 200 and self._message in _NOT_FOUND_MESSAGES) or self._code == 404:
+        if (self._code == 200 and self._message in self._NOT_FOUND_MESSAGES) or self._code == 404:
             raise PHPyPAMEntityNotFoundException(self._message)
         elif self._code == 500:
             if self._message == 'Invalid username or password':

--- a/phpypam/core/exceptions.py
+++ b/phpypam/core/exceptions.py
@@ -32,6 +32,7 @@ class PHPyPAMException(Exception):
             'No devices configured',
             'No results (filter applied)',
             'No objects found',
+            'Hostname not found'
         }
 
         if (self._code == 200 and self._message in _NOT_FOUND_MESSAGES) or self._code == 404:

--- a/tests/fixtures/test_entity_not_found_exception.yml
+++ b/tests/fixtures/test_entity_not_found_exception.yml
@@ -1,0 +1,390 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.24.0
+    method: POST
+    uri: https://ipam.example.org/api/ansible/user
+  response:
+    body:
+      string: '{"code":200,"success":true,"data":{"token":"FnNkF2HHbI7nK46Xo9TicJub","expires":"2021-09-02
+        22:22:15"},"time":0.01}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:15 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=fplgvj6f0mvh8p33o1djb5gkn3; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/subnets/cidr/1.2.3.4
+  response:
+    body:
+      string: '{"code":200,"success":false,"message":"No subnets found","time":0.004}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:15 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=s5gi4boskk3hot3qenrihhneqv; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/addresses/search/1.2.3.4
+  response:
+    body:
+      string: '{"code":200,"success":false,"message":"Address not found","time":0.006}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:15 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=1k5h5757fptr2k0lpdcfo3br6v; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vlans//1337
+  response:
+    body:
+      string: '{"code":200,"success":false,"message":"Vlan not found","time":0.003}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:15 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=pfc0uf9ui9drh2fvto3a3r1lne; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/vrf
+  response:
+    body:
+      string: '{"code":200,"success":false,"message":"No vrfs configured","time":0.003}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:16 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=3lub5a6jpcau7c4tucim8tas5g; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/devices//1337
+  response:
+    body:
+      string: '{"code":404,"success":false,"message":"Device not found","time":0.006}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:16 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=v3do4d2v2d87k396m2v9qshl9n; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/sections/?filter_by=name&filter_value=not_existing_section&filter_match=full
+  response:
+    body:
+      string: '{"code":404,"success":false,"message":"No results (filter applied)","time":0.003}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:16 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=6l9mul3i2d1hcspnuhrh86u03i; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/tools/device_types//1337
+  response:
+    body:
+      string: '{"code":200,"success":false,"message":"No objects found","time":0.003}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:16 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=hj4kk62gtbce36rmh0kjkhdt8e; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.24.0
+    method: GET
+    uri: https://ipam.example.org/api/ansible/addresses/search_hostname/not_existing_hostname/
+  response:
+    body:
+      string: '{"code":200,"success":false,"message":"Hostname not found","time":0.003}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 02 Sep 2021 14:22:16 GMT
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=5, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache/2.4.37 (centos) OpenSSL/1.1.1g
+      Set-Cookie:
+      - phpipam=80loa9fe9f6soe29ok8praedqu; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+        Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
+      Transfer-Encoding:
+      - chunked
+      X-Powered-By:
+      - PHP/7.2.24
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/test_entity_not_found_exception.yml
+++ b/tests/fixtures/test_entity_not_found_exception.yml
@@ -17,7 +17,7 @@ interactions:
   response:
     body:
       string: '{"code":200,"success":true,"data":{"token":"FnNkF2HHbI7nK46Xo9TicJub","expires":"2021-09-02
-        22:22:15"},"time":0.01}'
+        23:03:39"},"time":0.026}'
     headers:
       Cache-Control:
       - no-cache
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:15 GMT
+      - Thu, 02 Sep 2021 15:03:39 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -36,7 +36,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=fplgvj6f0mvh8p33o1djb5gkn3; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+      - phpipam=sks3vafc4ijohhrd002obonl9v; expires=Fri, 03 Sep 2021 15:03:39 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       X-Powered-By:
       - PHP/7.2.24
@@ -67,7 +67,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:15 GMT
+      - Thu, 02 Sep 2021 15:03:39 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -77,7 +77,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=s5gi4boskk3hot3qenrihhneqv; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+      - phpipam=iecmn27al98vo45j9bcba5sol9; expires=Fri, 03 Sep 2021 15:03:39 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -110,7 +110,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:15 GMT
+      - Thu, 02 Sep 2021 15:03:39 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -120,7 +120,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=1k5h5757fptr2k0lpdcfo3br6v; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+      - phpipam=ae8pe4uvc9nn0qjrc7naluuut4; expires=Fri, 03 Sep 2021 15:03:39 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -144,7 +144,7 @@ interactions:
     uri: https://ipam.example.org/api/ansible/vlans//1337
   response:
     body:
-      string: '{"code":200,"success":false,"message":"Vlan not found","time":0.003}'
+      string: '{"code":200,"success":false,"message":"Vlan not found","time":0.004}'
     headers:
       Cache-Control:
       - no-cache
@@ -153,7 +153,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:15 GMT
+      - Thu, 02 Sep 2021 15:03:39 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -163,7 +163,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=pfc0uf9ui9drh2fvto3a3r1lne; expires=Fri, 03 Sep 2021 14:22:15 +0000;
+      - phpipam=45kanoi8nrv3tr0j2p7sd18hga; expires=Fri, 03 Sep 2021 15:03:39 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -196,7 +196,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:16 GMT
+      - Thu, 02 Sep 2021 15:03:39 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -206,7 +206,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=3lub5a6jpcau7c4tucim8tas5g; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+      - phpipam=ghf8m3mg1jgffg2nhvipfv1v5m; expires=Fri, 03 Sep 2021 15:03:39 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -230,7 +230,7 @@ interactions:
     uri: https://ipam.example.org/api/ansible/devices//1337
   response:
     body:
-      string: '{"code":404,"success":false,"message":"Device not found","time":0.006}'
+      string: '{"code":404,"success":false,"message":"Device not found","time":0.004}'
     headers:
       Cache-Control:
       - no-cache
@@ -239,7 +239,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:16 GMT
+      - Thu, 02 Sep 2021 15:03:39 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -249,7 +249,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=v3do4d2v2d87k396m2v9qshl9n; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+      - phpipam=ms3o18qp73as0453ml9cem7er0; expires=Fri, 03 Sep 2021 15:03:40 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -282,7 +282,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:16 GMT
+      - Thu, 02 Sep 2021 15:03:40 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -292,7 +292,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=6l9mul3i2d1hcspnuhrh86u03i; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+      - phpipam=jacokfagbga30uqsktqpi2cvjv; expires=Fri, 03 Sep 2021 15:03:40 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -316,7 +316,7 @@ interactions:
     uri: https://ipam.example.org/api/ansible/tools/device_types//1337
   response:
     body:
-      string: '{"code":200,"success":false,"message":"No objects found","time":0.003}'
+      string: '{"code":200,"success":false,"message":"No objects found","time":0.004}'
     headers:
       Cache-Control:
       - no-cache
@@ -325,7 +325,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:16 GMT
+      - Thu, 02 Sep 2021 15:03:40 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -335,7 +335,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=hj4kk62gtbce36rmh0kjkhdt8e; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+      - phpipam=4osgafc1kbtn19o7hu29u7gug5; expires=Fri, 03 Sep 2021 15:03:40 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked
@@ -356,10 +356,10 @@ interactions:
       User-Agent:
       - python-requests/2.24.0
     method: GET
-    uri: https://ipam.example.org/api/ansible/addresses/search_hostname/not_existing_hostname/
+    uri: https://ipam.example.org/api/ansible/addresses/search_hostname/not_existing_hostname
   response:
     body:
-      string: '{"code":200,"success":false,"message":"Hostname not found","time":0.003}'
+      string: '{"code":200,"success":false,"message":"Hostname not found","time":0.004}'
     headers:
       Cache-Control:
       - no-cache
@@ -368,7 +368,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 02 Sep 2021 14:22:16 GMT
+      - Thu, 02 Sep 2021 15:03:40 GMT
       Expires:
       - Thu, 19 Nov 1981 08:52:00 GMT
       Keep-Alive:
@@ -378,7 +378,7 @@ interactions:
       Server:
       - Apache/2.4.37 (centos) OpenSSL/1.1.1g
       Set-Cookie:
-      - phpipam=80loa9fe9f6soe29ok8praedqu; expires=Fri, 03 Sep 2021 14:22:16 +0000;
+      - phpipam=ak5asjgl554okb6a80e6jjso8i; expires=Fri, 03 Sep 2021 15:03:40 +0000;
         Max-Age=86400; path=/; SameSite=Lax; HttpOnly;
       Transfer-Encoding:
       - chunked

--- a/tests/test_cases/search_exceptions.py
+++ b/tests/test_cases/search_exceptions.py
@@ -1,5 +1,4 @@
 """Test exceptions."""
-from vcr import record_mode
 import phpypam
 import pytest
 import vcr
@@ -30,7 +29,7 @@ not_found_cases = [
     dict(controller='devices', path='/1337'),
     dict(controller='sections', params={'filter_by': 'name', 'filter_value': 'not_existing_section', 'filter_match': 'full'}),
     dict(controller='tools/device_types', path='/1337'),
-    dict(controller='addresses', path=f"search_hostname/not_existing_hostname/")
+    dict(controller='addresses', path='search_hostname/not_existing_hostname')
 ]
 
 

--- a/tests/test_cases/search_exceptions.py
+++ b/tests/test_cases/search_exceptions.py
@@ -19,8 +19,6 @@ connection_params = dict(
     ssl_verify=True
 )
 
-not_found_messages = PHPyPAMException._NOT_FOUND_MESSAGES
-
 not_found_cases = [
     dict(controller='subnets', path='cidr/1.2.3.4', params=None),
     dict(controller='addresses', path='search/1.2.3.4'),
@@ -53,4 +51,4 @@ def test_entity_not_found_exception(case):
         pi.get_entity(case['controller'], controller_path=case.pop('path', None), params=case.pop('params', None))
 
         # assert exception message is in all not found outputs
-        assert e.value.args[0] in not_found_cases
+        assert e.value.args[0] in PHPyPAMException._NOT_FOUND_MESSAGES

--- a/tests/test_cases/search_exceptions.py
+++ b/tests/test_cases/search_exceptions.py
@@ -1,0 +1,57 @@
+"""Test exceptions."""
+from vcr import record_mode
+import phpypam
+import pytest
+import vcr
+import yaml
+
+from tests.conftest import filter_request_uri, filter_response, cassette_name, FILTER_REQUEST_HEADERS
+from phpypam.core.exceptions import PHPyPAMException, PHPyPAMEntityNotFoundException
+
+
+with open('tests/vars/server.yml') as c:
+    server = yaml.safe_load(c)
+
+connection_params = dict(
+    url=server['url'],
+    app_id=server['app_id'],
+    username=server['username'],
+    password=server['password'],
+    ssl_verify=True
+)
+
+not_found_messages = PHPyPAMException._NOT_FOUND_MESSAGES
+
+not_found_cases = [
+    dict(controller='subnets', path='cidr/1.2.3.4', params=None),
+    dict(controller='addresses', path='search/1.2.3.4'),
+    dict(controller='vlans', path='/1337'),
+    dict(controller='vrf'),
+    dict(controller='devices', path='/1337'),
+    dict(controller='sections', params={'filter_by': 'name', 'filter_value': 'not_existing_section', 'filter_match': 'full'}),
+    dict(controller='tools/device_types', path='/1337'),
+    dict(controller='addresses', path=f"search_hostname/not_existing_hostname/")
+]
+
+
+@vcr.use_cassette(cassette_name('test_entity_not_found_exception'),
+                  filter_headers=FILTER_REQUEST_HEADERS,
+                  before_record_request=filter_request_uri,
+                  before_recorde_response=filter_response,
+                  record_mode='rewrite'
+                  )
+@pytest.mark.parametrize('case', not_found_cases)
+def test_entity_not_found_exception(case):
+    """Test entity not found exception.
+
+    Test if PHPyPAMEntityNotFound exception is fired corretly for all cases.
+    """
+
+    pi = phpypam.api(**connection_params)
+
+    # check whether PHPyPAMEntityNotFoundException is raised
+    with pytest.raises(PHPyPAMEntityNotFoundException) as e:
+        pi.get_entity(case['controller'], controller_path=case.pop('path', None), params=case.pop('params', None))
+
+        # assert exception message is in all not found outputs
+        assert e.value.args[0] in not_found_cases


### PR DESCRIPTION
The following call raises a PHPyPAMException.

```
pi.get_entity(controller='addresses', controller_path=f"search_hostname/{hostname}/")
```

I would expect the library to raise PHPyPAMEntityNotFoundException instead. This PR fixes this by adding the error returned from phpipam to the expected list.
