### PR TITLE
Switch test to containerized services

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,25 +4,70 @@ on:
 - push
 
 jobs:
-  tests:
-
+  e2e_tests:
+    name: end to end tests
     runs-on: ubuntu-latest
-
+    services:
+      database:
+        image: mariadb:10.3.18
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ROOT_PASSWORD: "rootpw"
+          MYSQL_USER: "phpipam"
+          MYSQL_PASSWORD: "phpipamadmin"
+          MYSQL_DATABASE: "phpipam"
+      phpipam:
+        image: phpipam/phpipam-www:v1.4.4
+        ports:
+          - "443:443"
+        env:
+          IPAM_DATABASE_HOST: "database"
+          IPAM_DATABASE_USER: "phpipam"
+          IPAM_DATABASE_PASS: "phpipamadmin"
+          IPAM_DATABASE_NAME: "phpipam"
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Prepare test environment
-      env:
-        PHPIPAM_URL: ${{ secrets.PHPIPAM_URL }}
-        PHPIPAM_APPID: ${{ secrets.PHPIPAM_APPID }}
-        PHPIPAM_USERNAME: ${{ secrets.PHPIPAM_USERNAME }}
-        PHPIPAM_PASSWORD: ${{ secrets.PHPIPAM_PASSWORD }}
-      run: |
-        python -m pip install --upgrade pip
-        make test-setup
-    - name: Run all tests
-      run:
-        make test-all
+      - uses: actions/checkout@v2
+      - name: Checkout phpipam repo
+        uses: actions/checkout@v2
+        with:
+          repository: phpipam/phpipam
+          ref: v1.4.4
+          path: phpipam
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: setup test environment
+        run: |
+          make test-setup
+        env:
+          PHPIPAM_URL: "https://localhost"
+          PHPIPAM_APPID: "ansible"
+          PHPIPAM_USERNAME: "admin"
+          PHPIPAM_PASSWORD: "ipamadmin"
+          PHPIPAM_VALIDATE_CERTS: False
+      - name: "waiting for database to come online"
+        run: |
+          for i in `seq 1 10`;
+          do
+            nc -z 127.0.0.1 3306 && echo Success && exit 0
+            echo -n .
+            sleep 1
+          done
+          echo Failed waiting for MySQL && exit 1
+      - name: load data into database
+        run: |
+          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam < phpipam/db/SCHEMA.sql
+      - name: activate api
+        run: |
+          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam --execute="UPDATE settings SET api=1 WHERE id=1;"
+      - name: add api key for tests
+        run: |
+          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);"
+      - name: run all tests
+        run: |
+          make test-all
+        env:
+          PYTHONWARNINGS: "ignore:Unverified HTTPS request"
+          PHPIPAM_VALIDATE_CERTS: False

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifndef PHPIPAM_VALIDATE_CERTS
+override PHPIPAM_VALIDATE_CERTS = true
+endif
+
 ifdef PYPI_REPO
 TWINE_OPTIONS = --repository $(PYPI_REPO)
 endif
@@ -60,7 +64,7 @@ test-setup: | tests/vars/server.yml
 	pip install --upgrade -r requirements-dev.txt
 
 tests/vars/server.yml:
-	sed -e "s#~~url~~#$(PHPIPAM_URL)#" -e "s#~~app_id~~#$(PHPIPAM_APPID)#" -e "s#~~username~~#$(PHPIPAM_USERNAME)#" -e "s#~~password~~#$(PHPIPAM_PASSWORD)#" $@.example > $@
+	sed -e "s#~~url~~#$(PHPIPAM_URL)#" -e "s#~~app_id~~#$(PHPIPAM_APPID)#" -e "s#~~username~~#$(PHPIPAM_USERNAME)#" -e "s#~~password~~#$(PHPIPAM_PASSWORD)#" -e "s#~~ssl_verify~~#$(PHPIPAM_VALIDATE_CERTS)#" $@.example > $@
 
 test-all:
 	coverage run -m pytest tests/test_cases/* -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def pi(*arg, **kwargs):
     app_id = kwargs.pop('app_id', server['app_id'])
     username = kwargs.pop('username', server['username'])
     password = kwargs.pop('password', server['password'])
-    ssl_verify = kwargs.pop('ssl_verify', True)
+    ssl_verify = kwargs.pop('ssl_verify', server['ssl_verify'])
 
     return phpypam.api(
         url=url,

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  phpipam:
+    image: phpipam/phpipam-www:v1.4.4
+    ports:
+      - "443:443"
+    environment:
+      IPAM_DATABASE_HOST: "database"
+      IPAM_DATABASE_USER: "phpipam"
+      IPAM_DATABASE_PASS: "phpipamadmin"
+      IPAM_DATABASE_NAME: "phpipam"
+    depends_on:
+      - database
+  database:
+    image: mariadb:10.3.18
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: "rootpw"
+      MYSQL_USER: "phpipam"
+      MYSQL_PASSWORD: "phpipamadmin"
+      MYSQL_DATABASE: "phpipam"

--- a/tests/docker/setup_database.sh
+++ b/tests/docker/setup_database.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+while ! nc -z "${DB_HOST:-127.0.0.1}" "${DB_PORT:-3306}"; do
+  echo "Waiting for database connection..."
+  sleep 1
+done
+
+echo "Database is up"
+
+echo "Creating database ${DB_NAME:-phpipam}"
+docker exec -ti docker_phpipam_1 sh -c 'mysql -h database -u phpipam -pphpipamadmin phpipam < /phpipam/db/SCHEMA.sql'
+
+echo "Activating API"
+mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="UPDATE settings SET api=1 WHERE id=1;"
+
+echo "Inserting API application"
+mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);"

--- a/tests/vars/server.yml.example
+++ b/tests/vars/server.yml.example
@@ -3,3 +3,4 @@ url: ~~url~~
 app_id: ~~app_id~~
 username: ~~username~~
 password: ~~password~~
+ssl_verify: ~~ssl_verify~~


### PR DESCRIPTION
Like in codeaffen/phpipam-ansible-modules we want to run tests agains
phpipam installation with containerized services here too. So we adapt
the solution from there and switch our CI workflow to that approach
For that we have to add ssl_verify to connection params and set default
in Makefile