### PR TITLE
Switch workflow to phpipam-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,38 +7,11 @@ jobs:
   e2e_tests:
     name: end to end tests
     runs-on: ubuntu-latest
-    services:
-      database:
-        image: mariadb:10.3.18
-        ports:
-          - "3306:3306"
-        env:
-          MYSQL_ROOT_PASSWORD: "rootpw"
-          MYSQL_USER: "phpipam"
-          MYSQL_PASSWORD: "phpipamadmin"
-          MYSQL_DATABASE: "phpipam"
-      phpipam:
-        image: phpipam/phpipam-www:v1.4.4
-        ports:
-          - "443:443"
-        env:
-          IPAM_DATABASE_HOST: "database"
-          IPAM_DATABASE_USER: "phpipam"
-          IPAM_DATABASE_PASS: "phpipamadmin"
-          IPAM_DATABASE_NAME: "phpipam"
     steps:
       - uses: actions/checkout@v2
-      - name: Checkout phpipam repo
-        uses: actions/checkout@v2
-        with:
-          repository: phpipam/phpipam
-          ref: v1.4.4
-          path: phpipam
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: setup test environment
+      - name: setup phpipam
+        uses: codeaffen/phpipam-action@v1
+      - name: prepare tests
         run: |
           make test-setup
         env:
@@ -47,24 +20,6 @@ jobs:
           PHPIPAM_USERNAME: "admin"
           PHPIPAM_PASSWORD: "ipamadmin"
           PHPIPAM_VALIDATE_CERTS: False
-      - name: "waiting for database to come online"
-        run: |
-          for i in `seq 1 10`;
-          do
-            nc -z 127.0.0.1 3306 && echo Success && exit 0
-            echo -n .
-            sleep 1
-          done
-          echo Failed waiting for MySQL && exit 1
-      - name: load data into database
-        run: |
-          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam < phpipam/db/SCHEMA.sql
-      - name: activate api
-        run: |
-          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam --execute="UPDATE settings SET api=1 WHERE id=1;"
-      - name: add api key for tests
-        run: |
-          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);"
       - name: run all tests
         run: |
           make test-all


### PR DESCRIPTION
We now use our new `codeaffen/phpipam-action` to setup the phpipam instance.