### PR TITLE
feat: enable matrix tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,19 @@ jobs:
   e2e_tests:
     name: end to end tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        phpipam-version: ['1.4x', '1.5x']
+        python-version: ['3.7.x', '3.8.x', '3.9.x', '3.10.x']
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: setup phpipam
-        uses: codeaffen/phpipam-action@v1
+        uses: codeaffen/phpipam-action@v2
+        with:
+          ipam_version: ${{ matrix.phpipam-version }}
       - name: prepare tests
         run: |
           make test-setup


### PR DESCRIPTION
As `phpipam-action` now support different phpipam versions we switch
all tests to matrix builds. So we can test different combinations of
phpipam and python versions.