### PR TITLE
Fix #57 - add `headers` parameter to methods create, update and delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Add ability to use ```podman``` if available on your system to spin up local test environment.
 
 ### Fixes
+* \#57 - add headers parameter to methods create, update and delete
+  * to modify the the output format header `Content-Type: application/xml` is needed
+  * requests to `/addresses` endpoint needs sometimes `Content-Type: application/x-www-form-urlencoded` to work 
 
 * \#51 - Subnet address search with zero results raises incorrect exception
 

--- a/phpypam/core/api.py
+++ b/phpypam/core/api.py
@@ -166,7 +166,7 @@ class Api(object):
 
         return self._query(token=self._api_token, method=GET, path=_path, params=_params)
 
-    def create_entity(self, controller, controller_path=None, data=None, params=None):
+    def create_entity(self, controller, controller_path=None, data=None, params=None, headers=None):
         """Create an entity.
 
         :param controller: Name of the controller to use.
@@ -177,6 +177,8 @@ class Api(object):
         :type data: dict
         :param params: Dictionary list of tuples or bytes to send in the query string for the :class:`Request`., defaults to None
         :type params: dict, optional
+        :param headers: Optional request headers, defaults to None
+        :type headers: dict, optional
 
         :return: Returns the newly created entity.
         :rtype: Union[dict, list]
@@ -184,13 +186,14 @@ class Api(object):
         _path = controller
         _controller_path = controller_path
         _params = params
+        _headers = headers
 
         if _controller_path:
             _path = '{}/{}'.format(_path, _controller_path)
 
-        return self._query(token=self._api_token, method=POST, path=_path, data=data, params=_params)
+        return self._query(token=self._api_token, method=POST, path=_path, data=data, params=_params, headers=_headers)
 
-    def delete_entity(self, controller, controller_path, params=None):
+    def delete_entity(self, controller, controller_path, params=None, headers=None):
         """Delete an entity.
 
         :param controller: Name of the controller to use.
@@ -199,16 +202,19 @@ class Api(object):
         :type controller_path: str
         :param params: Dictionary, list of tuples or bytes to send in the query string for the :class:`Request`., defaults to None
         :type params: dict, optional
+        :param headers: Optional request headers, defaults to None
+        :type headers: dict, optional
 
         :return: Returns True if entity was deleted successfully or either 'dict' or 'list' of entities to work on.
         :rtype: Union[book, dict, list]
         """
         _path = '{}/{}'.format(controller, controller_path)
         _params = params
+        _headers = headers
 
-        return self._query(token=self._api_token, method=DELETE, path=_path, params=_params)
+        return self._query(token=self._api_token, method=DELETE, path=_path, params=_params, headers=_headers)
 
-    def update_entity(self, controller, controller_path=None, data=None, params=None):
+    def update_entity(self, controller, controller_path=None, data=None, params=None, headers=None):
         """Update an entity.
 
         :param controller: Name of the controller to use.
@@ -219,6 +225,8 @@ class Api(object):
         :type data: dict, optional
         :param params: Dictionary list of tuples or bytes to send in the query string for the :class:`Request`., defaults to None
         :type params: dict, optional
+        :param headers: Optional request headers, defaults to None
+        :type headers: dict, optional
 
         :return: Returns either a 'dict' or 'list' of the changed entity
         :rtype: Union[dict, list]
@@ -226,11 +234,12 @@ class Api(object):
         _path = controller
         _controller_path = controller_path
         _params = params
+        _headers = headers
 
         if _controller_path:
             _path = '{}/{}'.format(_path, _controller_path)
 
-        return self._query(token=self._api_token, method=PATCH, path=_path, data=data, params=_params)
+        return self._query(token=self._api_token, method=PATCH, path=_path, data=data, params=_params, headers=_headers)
 
     def controllers(self):
         """Report all controllers from phpIPAM API.

--- a/phpypam/core/api.py
+++ b/phpypam/core/api.py
@@ -141,7 +141,7 @@ class Api(object):
         """
         return self._api_token
 
-    def get_entity(self, controller, controller_path=None, params=None):
+    def get_entity(self, controller, controller_path=None, params=None, headers=None):
         """Get existing entity from phpIPAM server.
 
         This method query for existing entity. It there a result it will be returned otherwise
@@ -153,6 +153,8 @@ class Api(object):
         :type controller_path: str, optional
         :param params: Request parameters which have to be append to the request URI, defaults to None
         :type params: dict, optional
+        :param headers: Optional request headers, defaults to None
+        :type headers: dict, optional
 
         :return: Result of the query. It can be either a 'list' or 'dict'.
         :rtype: Union[dict, list]
@@ -160,11 +162,12 @@ class Api(object):
         _path = controller
         _controller_path = controller_path
         _params = params
+        _headers = headers
 
         if _controller_path:
             _path = '{}/{}'.format(_path, _controller_path)
 
-        return self._query(token=self._api_token, method=GET, path=_path, params=_params)
+        return self._query(token=self._api_token, method=GET, path=_path, params=_params, headers=None)
 
     def create_entity(self, controller, controller_path=None, data=None, params=None, headers=None):
         """Create an entity.


### PR DESCRIPTION
* Add `headers` parameter to methods `create`, `update` and `delete`
* Pass `headers` to internal method `_query`