### PR TITLE
Security/fix requests version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         phpipam-version: ['1.4x', '1.5x']
-        python-version: ['3.6.x', '3.7.x', '3.8.x', '3.9.x', '3.10.x']
+        python-version: ['3.7.x', '3.8.x', '3.9.x', '3.10.x']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/Makefile
+++ b/Makefile
@@ -20,17 +20,17 @@ default: help
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
-		@echo "  help  			  - to show this message"
-		@echo "  dist  			  - to build the collection archive"
-		@echo "  lint  			  - to run code linting"
-		@echo "  clean 			  - clean workspace"
-		@echo "  doc-setup    - prepare environment for creating documentation"
-		@echo "  doc          - create documentation"
-		@echo "  test-setup   - prepare environment for tests"
-		@echo "  test-all     - run all tests"
-		@echo "  test-<test>  - run a specifig test"
-		@echo "  coverage     - display code coverage"
-		@echo "  coverage-xml - create xml coverage report"
+		@echo "  help 			- to show this message"
+		@echo "  dist 			- to build the collection archive"
+		@echo "  lint 			- to run code linting"
+		@echo "  clean			- clean workspace"
+		@echo "  doc-setup		- prepare environment for creating documentation"
+		@echo "  docs 			- create documentation"
+		@echo "  test-setup		- prepare environment for tests"
+		@echo "  test-all		- run all tests"
+		@echo "  test-<test>		- run a specifig test"
+		@echo "  coverage		- display code coverage"
+		@echo "  coverage-xml		- create xml coverage report"
 
 lint:
 	flake8 phpypam

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ changelog-cli
 flake8
 flake8-colors
 flake8-docstrings
-requests~=2.24.0
+requests >=2.31,<3.0
 inflection
 twine
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests
+requests >=2.21,<3.0
 inflection

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
     keywords='api phpipam',
     python_requires='>=3.6',
     install_requires=[
-        'requests (>=2.21,<3.0)',
+        'requests (>=2.31,<3.0)',
     ],
 )


### PR DESCRIPTION
As of some security concerns we decided to increase the minimum `requests` version. 

This change need to do some adaption in our test suite. We switch the runner image to `ubuntu-20.04` to guarantee to have older python versions available. And we remove python 3.6 as there is no guarantee that the needed `request ` version is available.