### PR TITLE
Fix deprecation warning issue

### DIFF
--- a/phpypam/__init__.py
+++ b/phpypam/__init__.py
@@ -1,10 +1,11 @@
 """Package that provides phpIPAM API interface."""
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
 from phpypam.core.api import Api as api
 from phpypam.core.exceptions import PHPyPAMEntityNotFoundException
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+
     pass


### PR DESCRIPTION
As `pkg_resources` was deprecated we switched to `importlib.metadata` to get the same data.

/fixes #63 